### PR TITLE
Fix readme layout issues and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The ASK is available at: https://developer.amazon.com/public/solutions/alexa/ale
 ** Name: Anything you want it to be - I use Nest Control
 ** Invocation Name: The hotword to call the app - I have gotten it working with Nest
 ** Version: 1.0 <- This is hard-coded for now
-** Endpoint: https://<domain or ip address>/alexa/EchoPyAPI
+** Endpoint: https://\<domain or ip address\>/alexa/EchoPyAPI
 2. Go to the next page and copy the intentSchema.json to the Intent Schema and sampleUtterances.txt to the Sample Utterances
 2. Go to the next page and upload the selfsigned SSL Cert you have.. and hit next..
 
@@ -61,14 +61,14 @@ Nest developer is available at: https://developer.nest.com
 3. Fill out the form:
 ** Name: Anything - I use EchoPy
 ** Support URL: If you have a domain.. or github?
-** OAuth Redirect URL: https://<domain or ip address>/alexa/oauth2
+** OAuth Redirect URL: https://\<domain or ip address\>/alexa/oauth2
 ** Make sure that you click on read/write on all options that you can (some are unavailable) and give a short description (you have to..)
 3. Click Update Client
 3. From the clients page copy the Authorization URL and put it in nestpy_settings.py as nest_auth_uri_1 (sample at SAMPLE_nestpy_settings.py)
 3. From the clients page copy the Access Token URL and put it in nestpy_settings.py as nest_auth_uri_3
 
 ### Test
-At this point you should be able to go to https://<domain or ip address>/alexa/ and see a basic page.. If this works your'e good to go! 
+At this point you should be able to go to https://\<domain or ip address\>/alexa/ and see a basic page.. If this works your'e good to go! 
 
 
 ## Usage
@@ -78,7 +78,7 @@ run: python echopy.py
 
 At this time you will have to go to your Echo and say 'Alexa, Talk to Nest' (Replace Nest with what the Invocation Name you set). It should say that you are an unautherized Nest user and to check the card in your Echo App. Open the Echo app and look at the card there. It should give you what your User ID is.. (A bunch of random text) 
 
-Go to https://<domain or ip address>/alexa/auth/<Full UserId> 
+Go to https://\<domain or ip address\>/alexa/auth/\<Full UserId\> 
 
 This should allow you to authorize it to control your nest. Login to your Nest account and Authorize it.. It should bring you back to the root Alexa page. 
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ The ASK is available at: https://developer.amazon.com/public/solutions/alexa/ale
 2. Click on Alexa
 2. Click Add New Skill
 2. Fill out the first form:
-** Name: Anything you want it to be - I use Nest Control
-** Invocation Name: The hotword to call the app - I have gotten it working with Nest
-** Version: 1.0 <- This is hard-coded for now
-** Endpoint: https://\<domain or ip address\>/alexa/EchoPyAPI
+  * Name: Anything you want it to be - I use Nest Control
+  * Invocation Name: The hotword to call the app - I have gotten it working with Nest
+  * Version: 1.0 \<- This is hard-coded for now
+  * Endpoint: https://\<domain or ip address\>/alexa/EchoPyAPI
 2. Go to the next page and copy the intentSchema.json to the Intent Schema and sampleUtterances.txt to the Sample Utterances
 2. Go to the next page and upload the selfsigned SSL Cert you have.. and hit next..
 
@@ -59,10 +59,10 @@ Nest developer is available at: https://developer.nest.com
 3. Click on Clients
 3. Click Register New Client
 3. Fill out the form:
-** Name: Anything - I use EchoPy
-** Support URL: If you have a domain.. or github?
-** OAuth Redirect URL: https://\<domain or ip address\>/alexa/oauth2
-** Make sure that you click on read/write on all options that you can (some are unavailable) and give a short description (you have to..)
+  * Name: Anything - I use EchoPy
+  * Support URL: If you have a domain.. or github?
+  * OAuth Redirect URL: https://\<domain or ip address\>/alexa/oauth2
+  * Make sure that you click on read/write on all options that you can (some are unavailable) and give a short description (you have to..)
 3. Click Update Client
 3. From the clients page copy the Authorization URL and put it in nestpy_settings.py as nest_auth_uri_1 (sample at SAMPLE_nestpy_settings.py)
 3. From the clients page copy the Access Token URL and put it in nestpy_settings.py as nest_auth_uri_3

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Nest developer is available at: https://developer.nest.com
   * Make sure that you click on read/write on all options that you can (some are unavailable) and give a short description (you have to..)
 3. Click Update Client
 3. From the clients page copy the Authorization URL and put it in nestpy_settings.py as nest_auth_uri_1 (sample at SAMPLE_nestpy_settings.py)
-3. From the clients page copy the Access Token URL and put it in nestpy_settings.py as nest_auth_uri_3
+3. From the clients page copy the Access Token URL and put it in nestpy_settings.py as nest_auth_uri_2
 
 ### Test
 At this point you should be able to go to https://\<domain or ip address\>/alexa/ and see a basic page.. If this works your'e good to go! 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Sample Interactions:
 * Alexa, Tell Nest that I am too warm. 
 * Alexa, Tell Nest to turn the temperature up. 
 
-More deatils and videos at: https://zpriddy.com/?p=68
+More details and videos at: https://zpriddy.com/?p=68
 
 ## Requirements and setup
 
@@ -49,7 +49,7 @@ The ASK is available at: https://developer.amazon.com/public/solutions/alexa/ale
   * Version: 1.0 \<- This is hard-coded for now
   * Endpoint: https://\<domain or ip address\>/alexa/EchoPyAPI
 2. Go to the next page and copy the intentSchema.json to the Intent Schema and sampleUtterances.txt to the Sample Utterances
-2. Go to the next page and upload the selfsigned SSL Cert you have.. and hit next..
+2. Go to the next page and upload the self-signed SSL Cert you have.. and hit next..
 
 ### Setting Up Nest Developer Token
 
@@ -68,7 +68,7 @@ Nest developer is available at: https://developer.nest.com
 3. From the clients page copy the Access Token URL and put it in nestpy_settings.py as nest_auth_uri_2
 
 ### Test
-At this point you should be able to go to https://\<domain or ip address\>/alexa/ and see a basic page.. If this works your'e good to go! 
+At this point you should be able to go to https://\<domain or ip address\>/alexa/ and see a basic page.. If this works you're good to go! 
 
 
 ## Usage
@@ -91,7 +91,7 @@ The NestPy is another project that I have been working on that I am about to pos
 
 
 ### To Do:
-* Add chnage mode to Nest and Alexa for Away / Home
+* Add change mode to Nest and Alexa for Away / Home
 * Add better support for multi-Nest Households. 
 * Add check in time of inbound requests for security.
 * Improve sample utterances


### PR DESCRIPTION
This fixes a few issues I noticed with the rendering of the README on github:
- Escape out the angle brackets so they show up
- Nest the lists of settings in amazon and nest
- Fix a typo where nest_auth_uri_2 is referenced as nest_auth_uri_3
