### PR TITLE
Fixes #6: Set temperature not working

### DIFF
--- a/nestpy_lib.py
+++ b/nestpy_lib.py
@@ -80,7 +80,7 @@ def setTemperatureTargetAll(userId,temp):
 		print "Device:" + device
 		command_uri = 'https://developer-api.nest.com/devices/thermostats/' + device + "?auth=" + token
 		print command_uri
-		response = requests.put(url=command_uri, data=command, json=command)
+		response = requests.put(url=command_uri, json=command)
 		print response
 		print response.text
 		if response.status_code != 200:
@@ -105,7 +105,7 @@ def setTurnDownTemperatureAll(userId):
 		deviceId = thermostats[device]['id']
 		command = {"target_temperature_f":int(currentTemp)-2}
 		command_uri = 'https://developer-api.nest.com/devices/thermostats/' + deviceId + "?auth=" + token
-		response = requests.put(url=command_uri, data=command, json=command)
+		response = requests.put(url=command_uri, json=command)
 		if response.status_code != 200:
 			commandSucessfull = False
 
@@ -130,7 +130,7 @@ def setTurnUpTemperatureAll(userId):
 		deviceId = thermostats[device]['id']
 		command = {"target_temperature_f":int(currentTemp)+2}
 		command_uri = 'https://developer-api.nest.com/devices/thermostats/' + deviceId + "?auth=" + token
-		response = requests.put(url=command_uri, data=command, json=command)
+		response = requests.put(url=command_uri, json=command)
 		if response.status_code != 200:
 			commandSucessfull = False
 	
@@ -152,7 +152,7 @@ def setModeAll(userId,mode):
 
 	for structure in structures:
 		command_uri = 'https://developer-api.nest.com/structures/' + structure + "?auth=" + token
-		response = requests.put(url=command_uri, data=command, json=command)
+		response = requests.put(url=command_uri, json=command)
 		if response.status_code != 200:
 			commandSucessfull = False
 


### PR DESCRIPTION
I enabled debugging of the Nest API request, and saw this:

```
PUT /devices/thermostats/{deviceid}?auth={auth}
HTTP/1.1
Host: firebase-apiserver09-tah01-iad01.dapi.production.nest.com:9553
Content-Length: 23
Accept-Encoding: gzip, deflate
Accept: */*
User-Agent: python-requests/2.9.0
Connection: keep-alive
Content-Type: application/x-www-form-urlencoded

target_temperature_f=67
```

The `data=command, json=command` was causing the command to be sent as form data, and it appears support for that has been removed from the Nest API.  After this fix the requests look like:

```
PUT /devices/thermostats/{deviceid}?auth={auth}
HTTP/1.1
Host: firebase-apiserver09-tah01-iad01.dapi.production.nest.com:9553
Content-Length: 28
Accept-Encoding: gzip, deflate
Accept: */*
User-Agent: python-requests/2.9.0
Connection: keep-alive
Content-Type: application/json

{"target_temperature_f": 68}
```
